### PR TITLE
Colored text for sliders

### DIFF
--- a/crates/config/src/widgets/slide/base.rs
+++ b/crates/config/src/widgets/slide/base.rs
@@ -33,9 +33,9 @@ pub struct SlideConfig {
     #[serde(default = "dt_border_color")]
     #[serde(deserialize_with = "common::color_translate")]
     pub border_color: Color,
-    #[serde(default = "dt_text_color")]
-    #[serde(deserialize_with = "common::color_translate")]
-    pub text_color: Color,
+    #[serde(default)]
+    #[serde(deserialize_with = "common::option_color_translate")]
+    pub text_color: Option<Color>,
 
     #[serde(default)]
     pub redraw_only_on_internal_update: bool,
@@ -55,9 +55,6 @@ fn dt_fg_color() -> Color {
 }
 fn dt_border_color() -> Color {
     parse_color("#646464").unwrap()
-}
-fn dt_text_color() -> Color {
-    parse_color("#000000").unwrap()
 }
 fn dt_obtuse_angle() -> f64 {
     120.

--- a/crates/config/src/widgets/slide/base.rs
+++ b/crates/config/src/widgets/slide/base.rs
@@ -35,7 +35,10 @@ pub struct SlideConfig {
     pub border_color: Color,
     #[serde(default)]
     #[serde(deserialize_with = "common::option_color_translate")]
-    pub text_color: Option<Color>,
+    pub fg_text_color: Option<Color>,
+    #[serde(default)]
+    #[serde(deserialize_with = "common::option_color_translate")]
+    pub bg_text_color: Option<Color>,
 
     #[serde(default)]
     pub redraw_only_on_internal_update: bool,

--- a/crates/config/src/widgets/slide/preset.rs
+++ b/crates/config/src/widgets/slide/preset.rs
@@ -30,6 +30,10 @@ pub struct PulseAudioConfig {
     #[serde(deserialize_with = "super::super::common::color_translate")]
     pub mute_color: Color,
     #[serde(default)]
+    #[serde(deserialize_with = "super::super::common::option_color_translate")]
+    pub mute_text_color: Option<Color>,
+    
+    #[serde(default)]
     pub animation_curve: Curve,
     pub device: Option<String>,
 }

--- a/crates/frontend/src/widgets/slide/base/draw.rs
+++ b/crates/frontend/src/widgets/slide/base/draw.rs
@@ -21,6 +21,8 @@ pub struct DrawConfig {
 
     bg_color: Color,
     pub fg_color: Color,
+    // if None we want to use half fg and bg and split at the seam
+    pub text_color: Option<Color>, 
     border_color: Color,
 
     func: fn(&DrawConfig, f64) -> ImageSurface,
@@ -46,6 +48,7 @@ impl DrawConfig {
             bg_color: slide_conf.bg_color,
             fg_color: slide_conf.fg_color,
             border_color: slide_conf.border_color,
+            text_color: slide_conf.text_color,
             func,
         }
     }
@@ -203,7 +206,13 @@ impl DrawData {
                 .unwrap();
 
             let (mask_surf, ctx) = self.new_surface_bar();
-            cairo_set_color(&ctx, conf.bg_color);
+
+            if let Some(col) = conf.text_color {
+                cairo_set_color(&ctx, col);
+            } else {
+                cairo_set_color(&ctx, conf.bg_color);
+            }
+
             ctx.mask_surface(&self.fg_surf, Z, Z).unwrap();
 
             let (final_surf, ctx) = self.new_surface_bar();
@@ -215,7 +224,13 @@ impl DrawData {
 
         let fg_text_surf = {
             let (fg_text_surf, ctx) = self.new_surface_bar();
-            cairo_set_color(&ctx, conf.fg_color);
+
+            if let Some(col) = conf.text_color {
+                cairo_set_color(&ctx, col);
+            } else {
+                cairo_set_color(&ctx, conf.fg_color);
+            }
+            
             ctx.mask_surface(normal_text_surf, text_start_pos.0, text_start_pos.1)
                 .unwrap();
 

--- a/crates/frontend/src/widgets/slide/base/draw.rs
+++ b/crates/frontend/src/widgets/slide/base/draw.rs
@@ -22,7 +22,8 @@ pub struct DrawConfig {
     bg_color: Color,
     pub fg_color: Color,
     // if None we want to use half fg and bg and split at the seam
-    pub text_color: Option<Color>, 
+    pub fg_text_color: Option<Color>,
+    pub bg_text_color: Option<Color>, 
     border_color: Color,
 
     func: fn(&DrawConfig, f64) -> ImageSurface,
@@ -48,7 +49,8 @@ impl DrawConfig {
             bg_color: slide_conf.bg_color,
             fg_color: slide_conf.fg_color,
             border_color: slide_conf.border_color,
-            text_color: slide_conf.text_color,
+            fg_text_color: slide_conf.fg_text_color,
+            bg_text_color: slide_conf.bg_text_color,
             func,
         }
     }
@@ -207,8 +209,8 @@ impl DrawData {
 
             let (mask_surf, ctx) = self.new_surface_bar();
 
-            if let Some(col) = conf.text_color {
-                cairo_set_color(&ctx, col);
+            if let Some(fg_text_color) = conf.fg_text_color {
+                cairo_set_color(&ctx, fg_text_color);
             } else {
                 cairo_set_color(&ctx, conf.bg_color);
             }
@@ -225,8 +227,8 @@ impl DrawData {
         let fg_text_surf = {
             let (fg_text_surf, ctx) = self.new_surface_bar();
 
-            if let Some(col) = conf.text_color {
-                cairo_set_color(&ctx, col);
+            if let Some(bg_text_color) = conf.bg_text_color {
+                cairo_set_color(&ctx, bg_text_color);
             } else {
                 cairo_set_color(&ctx, conf.fg_color);
             }

--- a/crates/frontend/src/widgets/slide/pulseaudio/mod.rs
+++ b/crates/frontend/src/widgets/slide/pulseaudio/mod.rs
@@ -35,6 +35,8 @@ pub struct PulseAudioContext {
 
     non_mute_color: Color,
     mute_color: Color,
+    non_mute_text_color: Color,
+    mute_text_color: Option<Color>,
     mute_animation: ToggleAnimationRc,
     draw_conf: DrawConfig,
 
@@ -46,6 +48,11 @@ impl WidgetContext for PulseAudioContext {
         let mute_y = self.mute_animation.borrow_mut().progress();
         let fg_color = color_transition(self.non_mute_color, self.mute_color, mute_y as f32);
         self.draw_conf.fg_color = fg_color;
+
+        if let Some(mute_text_color) = self.mute_text_color {
+            let bg_text_color = color_transition(self.non_mute_text_color, mute_text_color, mute_y as f32);
+            self.draw_conf.bg_text_color = Some(bg_text_color);
+        }
 
         let p = self.vinfo.get().vol;
         self.draw_conf.draw(p)
@@ -87,6 +94,8 @@ fn common(
     let mute_animation = builder.new_animation(200, preset_conf.animation_curve);
     let non_mute_color = w_conf.fg_color;
     let mute_color = preset_conf.mute_color;
+    let non_mute_text_color = w_conf.bg_text_color.unwrap_or(w_conf.fg_color);
+    let mute_text_color = preset_conf.mute_text_color;
     let vinfo = Rc::new(Cell::new(VInfo::default()));
 
     let vinfo_weak = Rc::downgrade(&vinfo);
@@ -114,6 +123,8 @@ fn common(
         vinfo,
         non_mute_color,
         mute_color,
+        non_mute_text_color,
+        mute_text_color,
         mute_animation,
         draw_conf: DrawConfig::new(&w_conf, conf.edge),
         progress_state: setup_event(conf, &mut w_conf),


### PR DESCRIPTION
This is a quick PR I wrote to allow for colored text in sliders different from fg/bg. I'm not sure if this is actually the right approach because it's still calculating the seams for fg and bg just using the same color for both. This also means that a transparent background color works and can still show up when you slide over it.

The documentation says an option for colored text exists yet there's no way to actually use it so this brings parity with the documentation. If this is not a change you want / you have an issue with the code please let me know and I will do my best to fix it.

![image](https://github.com/user-attachments/assets/16a624f0-a79a-4ab8-b2bb-c497e7c659bd)

