### PR TITLE
Ability to read config on write protected environments. Installation and Development using Nix Flakes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /target
 /result
+.direnv/bin
+.envrc
+.direnv

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -35,7 +35,7 @@ pub fn get_config_file_content() -> Result<String, String> {
     let p = get_config_path();
     let mut f = match OpenOptions::new()
         // .create(true)
-        .append(true)
+        //.append(true)
         .read(true)
         .open(p)
     {

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,96 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1741445498,
+        "narHash": "sha256-F5Em0iv/CxkN5mZ9hRn3vPknpoWdcdCyR0e4WklHwiE=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "52e3095f6d812b91b22fb7ad0bfc1ab416453634",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1736320768,
+        "narHash": "sha256-nIYdTAiKIGnFNugbomgBJR+Xv5F1ZQU+HfaBqJKroC0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4bc9c909d9ac828a039f288cf872d16d38185db8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1741573199,
+        "narHash": "sha256-A2sln1GdCf+uZ8yrERSCZUCqZ3JUlOv1WE2VFqqfaLQ=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "c777dc8a1e35407b0e80ec89817fe69970f4e81a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,146 @@
+{
+  description = "way-edges";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-24.11";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, rust-overlay, flake-utils }:
+    let
+      # Systems supported
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" ];
+      
+      # Helper function to generate packages for each system
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+      
+      # Function to get package for a system
+      packageFor = system:
+        let
+          overlays = [ (import rust-overlay) ];
+          pkgs = import nixpkgs { inherit system overlays; };
+          
+          rustPlatform = pkgs.makeRustPlatform {
+            cargo = pkgs.rust-bin.selectLatestNightlyWith (toolchain: toolchain.default);
+            rustc = pkgs.rust-bin.selectLatestNightlyWith (toolchain: toolchain.default);
+          };
+          
+          manifest = (pkgs.lib.importTOML ./crates/way-edges/Cargo.toml).package;
+        in
+        rustPlatform.buildRustPackage {
+          pname = manifest.name;
+          inherit (manifest) version;
+
+          buildInputs = with pkgs; [
+            libxkbcommon
+            cairo
+            libpulseaudio
+          ];
+
+          nativeBuildInputs = with pkgs; [
+            pkg-config
+          ];
+          
+          cargoLock = {
+            lockFile = ./Cargo.lock;
+            allowBuiltinFetchGit = true;
+          };
+
+          src = pkgs.lib.cleanSource ./.;
+                
+          RUSTFLAGS = "--cfg tokio_unstable";
+        };
+      
+      # Function to build dev shell
+      devShellFor = system:
+        let
+          pkgs = import nixpkgs { 
+            inherit system; 
+            overlays = [ (import rust-overlay) ];
+          };
+        in
+        pkgs.mkShell {
+          buildInputs = with pkgs; [
+            (rust-bin.selectLatestNightlyWith (toolchain: toolchain.default))
+            rust-analyzer
+            rustfmt
+            clippy
+            pkg-config
+            libxkbcommon
+            cairo
+            libpulseaudio
+          ];
+
+          RUSTFLAGS = "--cfg tokio_unstable";
+        };
+    in
+    {
+      # Generate per-system outputs
+      packages = forAllSystems (system: {
+        default = packageFor system;
+        way-edges = packageFor system;
+      });
+
+      devShells = forAllSystems (system: {
+        default = devShellFor system;
+      });
+
+      # Home manager module that doesn't depend on system-specific logic
+      homeManagerModules.default = { lib, pkgs, config, ... }:
+        let
+          cfg = config.programs.way-edges;
+        in
+        with lib; {
+          options.programs.way-edges = {
+            enable = mkEnableOption "way-edges";
+            
+            package = mkOption {
+              type = types.package;
+              description = "The way-edges package to use.";
+              default = self.packages.${pkgs.system}.way-edges;
+            };
+            
+            settings = mkOption {
+              type = types.attrs;
+              default = {};
+              description = "way-edges configuration.";
+              example = literalExpression ''
+                {
+                  groups = [
+                    {
+                      name = "hyprland";
+                      widgets = [
+                        {
+                          edge = "top";
+                          position = "right";
+                          layer = "overlay";
+                          monitor = "HDMI-A-1";
+                          widget = {
+                            type = "workspace";
+                            thickness = 25;
+                            length = "25%";
+                            hover_color = "#ffffff22";
+                            active_increase = 0.2;
+                            active_color = "#6B8EF0";
+                            deactive_color = "#000";
+                          };
+                        }
+                      ];
+                    }
+                  ];
+                }
+              '';
+            };
+          };
+          
+          config = mkIf cfg.enable {
+            home.packages = [ cfg.package ];
+            
+            xdg.configFile."way-edges/config.jsonc" = {
+              text = builtins.toJSON cfg.settings;
+            };
+          };
+        };
+    };
+}


### PR DESCRIPTION
# The changes are:

1. Addition of flake.nix and flake.lock file for installation and Development using Nix (home-manager).
2. Fix unable to read config in write protected environments since it opened the config file with append mode.

> Adding flake.nix makes default.nix redundant/obsolete because the build environment can be entered by `nix develop` and the program can be built by using the `nix build` command.

Using append mode is not necessary because the program doesn't interactively change the config. I tested all the command options, and they work as expected without it. This fixes the issue of not being able to read the config managed by nix because nix puts the configs in write protected mode.

> It is your decision to remove the default.nix file. And you can add the information below as install instructions on nix.

Here is a reference configuration using Nix(home-manager): 
https://gitlab.com/scientiac/einstein.nixos/-/blob/d1ac593073317cfbbd310f3a689402fb2681c9ee/home/niriwm/way-edges/default.nix

## Installation using Nix flake and home-manager:

```nix
# flake.nix

{

    inputs = {
        # ---Snip---
        way-edges = {
          url = "github:scientiac/way-edges";
          inputs.nixpkgs.follows = "nixpkgs";
        };
        # ---Snip---
    }
    # ---Snip---
}
```

## home.nix (home-manager)

```nix
{ inputs, pkgs, ... }: {
  imports = [ inputs.way-edges.homeManagerModules.default ];
  programs.way-edges = {
    enable = true;
    settings = {
      groups = [{
        name = "hyprland";
        widgets = [{
          edge = "top";
          position = "right";
          layer = "overlay";
          monitor = "HDMI-A-1";
          widget = {
            type = "workspace";
            thickness = 25;
            length = "25%";
            hover_color = "#ffffff22";
            active_increase = 0.2;
            active_color = "#6B8EF0";
            deactive_color = "#000";
          };
        }];
      }];
    };
  };
}
```