### PR TITLE
feat: Add focused_only workspace widget support

### DIFF
--- a/crates/backend/src/tray/context.rs
+++ b/crates/backend/src/tray/context.rs
@@ -39,6 +39,12 @@ pub struct TrayMap {
     pub(super) inner: HashMap<Arc<String>, Tray>,
 }
 impl TrayMap {
+    // Allow Arc<Mutex<TrayMap>> despite TrayMap not being Send+Sync due to cairo::ImageSurface.
+    // This is acceptable because:
+    // 1. Application uses single-threaded async runtime (LocalRuntime)
+    // 2. Arc<Mutex<...>> pattern required by Wayland API constraints (WlSurface::data needs Send+Sync)  
+    // 3. Cairo surfaces are inherently not thread-safe and shouldn't cross thread boundaries
+    #[allow(clippy::arc_with_non_send_sync)]
     fn new() -> Arc<Mutex<Self>> {
         Arc::new(Mutex::new(Self {
             inner: HashMap::new(),

--- a/crates/backend/src/workspace/mod.rs
+++ b/crates/backend/src/workspace/mod.rs
@@ -30,6 +30,7 @@ pub struct WorkspaceCB<T> {
     pub sender: Sender<WorkspaceData>,
     pub output: String,
     pub data: T,
+    pub focused_only: bool,
 }
 
 type ID = u32;
@@ -55,14 +56,15 @@ impl<T> WorkspaceCtx<T> {
     fn remove_cb(&mut self, id: ID) {
         self.cb.remove(&id);
     }
-    fn call(&mut self, mut data_func: impl FnMut(&str, &T) -> WorkspaceData) {
+    fn call(&mut self, mut data_func: impl FnMut(&str, &T, bool) -> Option<WorkspaceData>) {
         self.cb.values_mut().for_each(|f| {
-            let data = data_func(&f.output, &f.data);
-            // one output should always have a active workspace
-            assert!(data.active >= -1);
-            // the focus and active workspace should always be the same
-            assert!(data.focus < 0 || (data.focus == data.active));
-            f.sender.send(data).unwrap();
+            if let Some(data) = data_func(&f.output, &f.data, f.focused_only) {
+                // one output should always have a active workspace
+                assert!(data.active >= -1);
+                // the focus and active workspace should always be the same
+                assert!(data.focus < 0 || (data.focus == data.active));
+                f.sender.send(data).unwrap();
+            }
         })
     }
 }

--- a/crates/backend/src/workspace/mod.rs
+++ b/crates/backend/src/workspace/mod.rs
@@ -57,15 +57,24 @@ impl<T> WorkspaceCtx<T> {
         self.cb.remove(&id);
     }
     fn call(&mut self, mut data_func: impl FnMut(&str, &T, bool) -> Option<WorkspaceData>) {
-        self.cb.values_mut().for_each(|f| {
+        self.cb.values().for_each(|f| {
             if let Some(data) = data_func(&f.output, &f.data, f.focused_only) {
                 // one output should always have a active workspace
                 assert!(data.active >= -1);
                 // the focus and active workspace should always be the same
                 assert!(data.focus < 0 || (data.focus == data.active));
-                f.sender.send(data).unwrap();
+                f.sender.send(data).unwrap_or_else(|e| log::error!("Failed to send workspace data: {}",e));
             }
         })
+    }
+
+    fn sync_all_widgets_unconditionally(&self, mut data_func: impl FnMut(&str, &T) -> WorkspaceData) {
+        self.cb.values().for_each(|f| {
+            let data = data_func(&f.output, &f.data);
+            f.sender.send(data).unwrap_or_else(|e| {
+                log::error!("Error sending unconditional sync data: {}", e);
+            });
+        });
     }
 }
 

--- a/crates/config/src/widgets/workspace.rs
+++ b/crates/config/src/widgets/workspace.rs
@@ -57,6 +57,9 @@ pub struct WorkspaceConfig {
     #[serde(default)]
     pub output_name: Option<String>,
 
+    #[serde(default)]
+    pub focused_only: bool,
+
     pub preset: WorkspacePreset,
 }
 

--- a/crates/frontend/src/wayland/app.rs
+++ b/crates/frontend/src/wayland/app.rs
@@ -125,85 +125,6 @@ impl App {
         }
     }
 
-    pub fn handle_new_output(&mut self, output: &wayland_client::protocol::wl_output::WlOutput) {
-        log::info!("New output detected, creating widgets for existing groups");
-        
-        // Collect widget creation tasks to avoid borrowing conflicts
-        let mut widget_creation_tasks = Vec::new();
-        
-        for (group_name, group_opt) in &self.groups {
-            if let Some(group) = group_opt {
-                // Check each widget config to see if it should create a widget on the new output
-                for conf in &group.widget_configs {
-                    let should_create_widget = match &conf.monitor {
-                        MonitorSpecifier::ID(_) => {
-                            // For ID-based matching, we don't create new widgets on hot-plug
-                            // since the ID positions might have changed
-                            false
-                        }
-                        MonitorSpecifier::Names(items) => {
-                            self.output_state
-                                .info(output)
-                                .and_then(|info| info.name)
-                                .filter(|output_name| items.contains(output_name))
-                                .is_some()
-                        }
-                        MonitorSpecifier::All => true,
-                        _ => unreachable!(),
-                    };
-
-                    if should_create_widget {
-                        widget_creation_tasks.push((group_name.clone(), conf.clone()));
-                    }
-                }
-            }
-        }
-        
-        // Now create the widgets without borrowing conflicts
-        for (group_name, conf) in widget_creation_tasks {
-            match Widget::init_widget(conf.clone(), output.clone(), self) {
-                Ok(widget) => {
-                    if let Some(Some(group)) = self.groups.get_mut(&group_name) {
-                        group.map.entry(conf.name).or_default().push(widget);
-                        log::debug!("Created widget for group '{}' on new output", group_name);
-                    }
-                }
-                Err(e) => {
-                    log::error!("Failed to create widget for group '{}' on new output: {}", group_name, e);
-                    util::notify_send(
-                        "Way-edges hot-plug error",
-                        &format!("Failed to create widget for group '{}': {}", group_name, e),
-                        true
-                    );
-                }
-            }
-        }
-    }
-
-    pub fn handle_output_destroyed(&mut self, destroyed_output: &wayland_client::protocol::wl_output::WlOutput) {
-        log::info!("Output destroyed, cleaning up associated widgets");
-        
-        for (group_name, group_opt) in self.groups.iter_mut() {
-            if let Some(group) = group_opt {
-                for widgets in group.map.values_mut() {
-                    widgets.retain(|widget| {
-                        let should_keep = {
-                            let w = widget.lock().unwrap();
-                            // Keep widget if it's not associated with the destroyed output
-                            w.output != *destroyed_output
-                        };
-                        
-                        if !should_keep {
-                            log::debug!("Removing widget from group '{}' due to output destruction", group_name);
-                        }
-                        
-                        should_keep
-                    });
-                }
-            }
-        }
-    }
-
     fn init_group(&self, conf: config::Group) -> Option<Group> {
         log::debug!("group config:\n{conf:?}");
         Group::init_group(conf.widgets, self)
@@ -218,8 +139,6 @@ impl App {
 pub struct Group {
     // the `None` is for unnamed widgets
     map: HashMap<Option<String>, Vec<Arc<Mutex<Widget>>>>,
-    // Store original widget configs for hot-plug support
-    widget_configs: Vec<config::Config>,
 }
 impl Group {
     fn init_group(widgets_config: Vec<config::Config>, app: &App) -> Result<Self, String> {
@@ -261,10 +180,7 @@ impl Group {
             }
         }
 
-        Ok(Self {
-            map,
-            widget_configs: widgets_config,
-        })
+        Ok(Self { map })
     }
 
     fn get_widget(&self, name: &str) -> Option<Vec<Arc<Mutex<Widget>>>> {

--- a/crates/frontend/src/wayland/implement.rs
+++ b/crates/frontend/src/wayland/implement.rs
@@ -102,9 +102,8 @@ impl OutputHandler for App {
         &mut self,
         _conn: &Connection,
         _qh: &QueueHandle<Self>,
-        output: wl_output::WlOutput,
+        _output: wl_output::WlOutput,
     ) {
-        self.handle_new_output(&output);
     }
 
     fn update_output(
@@ -120,23 +119,14 @@ impl OutputHandler for App {
         &mut self,
         _conn: &Connection,
         _qh: &QueueHandle<Self>,
-        output: wl_output::WlOutput,
+        _output: wl_output::WlOutput,
     ) {
-        self.handle_output_destroyed(&output);
     }
 }
 
 impl LayerShellHandler for App {
     fn closed(&mut self, _conn: &Connection, _qh: &QueueHandle<Self>, _layer: &LayerSurface) {
-        // Don't automatically exit on layer surface closure
-        // The layer surface might be closed due to:
-        // 1. Output destruction (normal cleanup during hot-plug)
-        // 2. Widget cleanup (normal app behavior)
-        // 3. Compositor decision (unusual but shouldn't force exit)
-        // 
-        // Instead of exiting immediately, let the compositor or other mechanisms
-        // handle application shutdown when appropriate.
-        log::debug!("Layer surface closed");
+        self.exit = true
     }
 
     fn configure(

--- a/crates/frontend/src/wayland/implement.rs
+++ b/crates/frontend/src/wayland/implement.rs
@@ -102,8 +102,9 @@ impl OutputHandler for App {
         &mut self,
         _conn: &Connection,
         _qh: &QueueHandle<Self>,
-        _output: wl_output::WlOutput,
+        output: wl_output::WlOutput,
     ) {
+        self.handle_new_output(&output);
     }
 
     fn update_output(
@@ -119,14 +120,23 @@ impl OutputHandler for App {
         &mut self,
         _conn: &Connection,
         _qh: &QueueHandle<Self>,
-        _output: wl_output::WlOutput,
+        output: wl_output::WlOutput,
     ) {
+        self.handle_output_destroyed(&output);
     }
 }
 
 impl LayerShellHandler for App {
     fn closed(&mut self, _conn: &Connection, _qh: &QueueHandle<Self>, _layer: &LayerSurface) {
-        self.exit = true
+        // Don't automatically exit on layer surface closure
+        // The layer surface might be closed due to:
+        // 1. Output destruction (normal cleanup during hot-plug)
+        // 2. Widget cleanup (normal app behavior)
+        // 3. Compositor decision (unusual but shouldn't force exit)
+        // 
+        // Instead of exiting immediately, let the compositor or other mechanisms
+        // handle application shutdown when appropriate.
+        log::debug!("Layer surface closed");
     }
 
     fn configure(

--- a/crates/frontend/src/widgets/workspace/mod.rs
+++ b/crates/frontend/src/widgets/workspace/mod.rs
@@ -69,6 +69,7 @@ pub fn init_widget(
                 sender: $s,
                 output: $c.output_name.take().unwrap(),
                 data: $d,
+                focused_only: $c.focused_only,
             }
         };
     }

--- a/doc/config/all_in_one.jsonc
+++ b/doc/config/all_in_one.jsonc
@@ -100,6 +100,7 @@
             "output_name": "eDP-1", // not specified, it will use the output that this widget is on
             "pop_duration": 1000, // ms
             "workspace_transition_duration": 300, // ms
+            "focused_only": false, // only animate widgets on the currently focused monitor (works with both niri and Hyprland)
             // "preset": "hyprland",
             // "preset": "niri",
             "preset": {

--- a/doc/config/widgets/workspace.md
+++ b/doc/config/widgets/workspace.md
@@ -18,6 +18,7 @@
     "output_name": "eDP-1", // not specified, it will use the output that this widget is on
     "pop_duration": 1000, // ms
     "workspace_transition_duration": 300, // ms
+    "focused_only": false, // only show animation on the currently focused monitor
     // "preset": "hyprland",
     // "preset": "niri",
     "preset": {
@@ -43,8 +44,11 @@
 | output_name                   | not specified, it will use the output that this widget is on |
 | pop_duration                  | ms                                                           |
 | workspace_transition_duration | ms                                                           |
+| focused_only                  | only show workspaces on focused monitor: `true` or `false`   |
 | animation_curve               | animation curve                                              |
 | preset                        | `hyprland` or `niri` or `niri` with config                   |
+
+`focused_only`: On multi-monitor setups, when set to `true`, widgets will only animate on the currently focused monitor. When set to `false`, widgets animate on all monitors. This helps prevent unwanted animations on non-focused monitors when switching workspaces. **Available for both niri and Hyprland.**
 
 ## Preset: niri
 
@@ -57,13 +61,37 @@
 "preset": "niri",
 ```
 
-| Name         | Description            |
-| ------------ | ---------------------- |
-| type         | const `niri`           |
-| filter_empty | ignore empty workspace |
-
 ## Preset: hyprland
 
 ```jsonc
 "preset": "hyprland",
+```
+
+## Multi-Monitor Configuration Examples
+
+### Example: Focused-only animations
+
+```jsonc
+{
+  "preset": "hyprland",
+  "focused_only": true, // Only animate on currently focused monitor
+  "widget_configuration": {
+    "spacing": 5,
+  },
+}
+```
+
+### Example: Niri with focused-only animations
+
+```jsonc
+{
+  "preset": {
+    "type": "niri",
+    "filter_empty": true
+  },
+  "focused_only": true, // Only animate on currently focused monitor
+  "widget_configuration": {
+    "spacing": 8,
+  },
+}
 ```


### PR DESCRIPTION
Implement `focused_only` configuration option for workspace widgets to control animation behavior in multi-monitor environments. This PR also resolves a startup bug where widgets on non-focused monitors would not display the correct workspace information when `focused_only` was enabled. The previously included seamless hot-plug monitor support has been reverted in favor of a simpler widget reload mechanism.

Focused_only workspace widget implementation:
- Add `focused_only` field to WorkspaceConfig (defaults to `false`).
- Modify `WorkspaceCtx::call` to return `Option<WorkspaceData>` for conditional updates based on focus state.
- Implement focused monitor tracking in both niri and Hyprland backends.
- When enabled, workspace widgets only animate/update on the currently globally focused monitor.
- Fix Hyprland workspace widget to show workspaces per monitor with correct ordering.

Reverted Hot-Plug Monitor Support:
- The advanced hot-plug monitor support has been reverted.
- `App::reload()` is now called on monitor output changes (via `OutputHandler::update_output`), reinitializing widgets.

Startup Bug Fix for `focused_only`:
- Ensures all workspace widgets receive correct initial workspace data at startup, regardless of monitor focus or the `focused_only` setting.
- Achieved by:
    - Adding `is_default()` methods to backend data caches.
    - `add_cb` methods in backend contexts now defer initial data send if cache is not populated.
    - Added `WorkspaceCtx::sync_all_widgets_unconditionally(&self, mut data_func: impl FnMut(&str, &T) -> WorkspaceData)` for initial state sync.
    - This unconditional sync is called in Niri and Hyprland backends after initial cache population.

Technical changes:
- `crates/frontend/src/wayland/app.rs` and `implement.rs` reverted to simplify monitor change handling:
    - Removed `App::handle_new_output()` and `App::handle_output_destroyed()`.
    - `LayerShellHandler::closed()` now sets `self.exit = true;`.
    - `Group` struct no longer stores `widget_configs` for hot-plug.
- `focused_only` feature utilizes `Option<WorkspaceData>` from `WorkspaceCtx::call` and the `focused_only: bool` field in `WorkspaceCB`.
- Backend contexts (`NiriCtx`, `HyprCtx`) track the focused monitor.
- Document `Arc<Mutex<TrayMap>>` architecture for Wayland API constraints
- Add clippy suppression with detailed justification for `cairo::ImageSurface` thread safety

Bug fixes:
- Resolved: Workspace widgets on non-focused monitors now correctly display their initial workspace counts at startup when `focused_only` is enabled.

Implementation status:
- `focused_only` feature:
    - Niri: Implemented with focused output tracking and correct initial display.
    - Hyprland: Implemented with focused monitor tracking and correct initial display.
- Hot-plug Support: Reverted to widget reload on output changes.
- Backwards compatible: Existing configurations work unchanged. `focused_only` defaults to `false`.

The `focused_only` feature provides a smoother experience in multi-monitor setups, and it now initializes correctly on all monitors.