### PR TITLE
The fixes are comprehensive and address all these core issues:

### DIFF
--- a/crates/frontend/src/widgets/workspace/mod.rs
+++ b/crates/frontend/src/widgets/workspace/mod.rs
@@ -8,7 +8,7 @@ use crate::{
     wayland::app::WidgetBuilder,
 };
 use backend::workspace::{
-    hypr::{register_hypr_event_callback, HyprConf},
+    hypr::register_hypr_event_callback,
     niri::register_niri_event_callback,
     WorkspaceCB, WorkspaceData, WorkspaceHandler,
 };
@@ -74,8 +74,8 @@ pub fn init_widget(
     }
 
     let workspace_handler = match w_conf.preset.clone() {
-        WorkspacePreset::Hyprland => {
-            register_hypr_event_callback(wp_cb!(pop_signal_sender, w_conf, HyprConf))
+        WorkspacePreset::Hyprland(hypr_conf) => {
+            register_hypr_event_callback(wp_cb!(pop_signal_sender, w_conf, hypr_conf))
         }
         WorkspacePreset::Niri(niri_conf) => {
             register_niri_event_callback(wp_cb!(pop_signal_sender, w_conf, niri_conf))

--- a/doc/config/widgets/workspace.md
+++ b/doc/config/widgets/workspace.md
@@ -72,7 +72,19 @@ Which means scroll with 2 fingers on touchpad can not trigger anything in this w
 
 ```jsonc
 "preset": "hyprland",
+// or with configuration
+"preset": {
+  "type": "hyprland",
+  "show_empty": false, // Don't add extra workspace indicator when only one exists (default)
+},
+// to enable the extra workspace indicator:
+"preset": {
+  "type": "hyprland",
+  "show_empty": true, // Always show at least 2 workspace indicators
+},
 ```
+
+The Hyprland preset supports adding an extra empty workspace indicator when only one workspace exists on a monitor. When `show_empty` is set to `true`, it ensures there's always at least 2 workspace indicators visible (similar to Niri's behavior), preventing the widget from extending to the screen edge with a single workspace. The default is `false`.
 
 ## Multi-Monitor Configuration Examples
 
@@ -81,6 +93,18 @@ Which means scroll with 2 fingers on touchpad can not trigger anything in this w
 ```jsonc
 {
   "preset": "hyprland",
+  "focused-only": true, // Only animate on currently focused monitor
+}
+```
+
+### Example: Hyprland with empty workspace filtering
+
+```jsonc
+{
+  "preset": {
+    "type": "hyprland",
+    "show_empty": false, // Hide workspaces with no windows
+  },
   "focused-only": true, // Only animate on currently focused monitor
 }
 ```


### PR DESCRIPTION
1. Workspace counting - Now correctly counts actual workspaces regardless of ID gaps
2. Click handling - Properly maps index to workspace ID for non-contiguous IDs
3. Focus handling - Correctly distinguishes between global focus and monitor-specific active workspace
4. Visual consistency - Optional show_empty feature to prevent single workspace edge extension
5. Configuration - Proper infrastructure to support per-widget Hyprland settings