### PR TITLE
nix: update `RUSTFLAGS`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -34,5 +34,8 @@ rustPlatform.buildRustPackage {
 
   src = pkgs.lib.cleanSource ./.;
 
-  RUSTFLAGS = "--cfg tokio_unstable";
+  RUSTFLAGS = [
+    "--cfg tokio_unstable"
+    "--cfg tokio_uring"
+  ];
 }

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1749494155,
-        "narHash": "sha256-FG4DEYBpROupu758beabUk9lhrblSf5hnv84v1TLqMc=",
+        "lastModified": 1752866191,
+        "narHash": "sha256-NV4S2Lf2hYmZQ3Qf4t/YyyBaJNuxLPyjzvDma0zPp/M=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "88331c17ba434359491e8d5889cce872464052c2",
+        "rev": "f01fe91b0108a7aff99c99f2e9abbc45db0adc2a",
         "type": "github"
       },
       "original": {
@@ -29,11 +29,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749609482,
-        "narHash": "sha256-R+Y3tXIUAMosrgo/ynhIUPEONZ+cM0ScbgN7KA8OkoE=",
+        "lastModified": 1753066249,
+        "narHash": "sha256-j2UBrfDRIePGx3532Bbb9UeosNX2F73hfOAHtmACfnM=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "a17da8deb943e7c8b4151914abbfe33d5a4e5b0d",
+        "rev": "0751b65633a1785743ca44fd7c14a633c54c1f91",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -60,7 +60,10 @@
 
           src = pkgs.lib.cleanSource ./.;
 
-          RUSTFLAGS = "--cfg tokio_unstable";
+          RUSTFLAGS = [
+            "--cfg tokio_unstable"
+            "--cfg tokio_uring"
+          ];
 
           meta = {
             description = "Lightweight wayland client focusing on widgets hidden in your screen edge.";
@@ -92,7 +95,10 @@
             libpulseaudio
           ];
 
-          RUSTFLAGS = "--cfg tokio_unstable";
+          RUSTFLAGS = [
+            "--cfg tokio_unstable"
+            "--cfg tokio_uring"
+          ];
         };
     in
     {


### PR DESCRIPTION
Changes are based on commit https://github.com/way-edges/way-edges/commit/ad2b744b00384fd6c8374ebb3ba87591495d1b8a. Builds successfully with `nix build` and `nix build -f default.nix`.