### PR TITLE
feat: add offset for widgets

### DIFF
--- a/crates/config/src/common.rs
+++ b/crates/config/src/common.rs
@@ -168,7 +168,7 @@ struct ConfigShadow {
     pub layer: Layer,
 
     #[serde(default)]
-    pub offset: i32,
+    pub offset: NumOrRelative,
 
     #[serde(default)]
     pub margins: Margins,
@@ -243,7 +243,7 @@ pub struct CommonConfig {
     pub position: Anchor,
     #[schemars(schema_with = "schema_layer")]
     pub layer: Layer,
-    pub offset: i32,
+    pub offset: NumOrRelative,
     pub margins: Margins,
     pub monitor: MonitorSpecifier,
     pub namespace: String,
@@ -273,13 +273,16 @@ impl CommonConfig {
         calculate_margins!(self.margins.top, size.1);
         calculate_margins!(self.margins.bottom, size.1);
 
-        // extra
+        // offset & extra
+        let max = match self.edge {
+            Anchor::LEFT | Anchor::RIGHT => size.0,
+            Anchor::TOP | Anchor::BOTTOM => size.1,
+            _ => unreachable!(),
+        };
+        if self.offset.is_relative() {
+            self.offset.calculate_relative(max as f64);
+        }
         if self.extra_trigger_size.is_relative() {
-            let max = match self.edge {
-                Anchor::LEFT | Anchor::RIGHT => size.0,
-                Anchor::TOP | Anchor::BOTTOM => size.1,
-                _ => unreachable!(),
-            };
             self.extra_trigger_size.calculate_relative(max as f64);
         }
     }

--- a/crates/frontend/src/wayland/app.rs
+++ b/crates/frontend/src/wayland/app.rs
@@ -786,7 +786,7 @@ impl<'a> WidgetBuilder<'a> {
             layer.set_exclusive_zone(-1);
         };
 
-        let offset = common.offset;
+        let offset = common.offset.get_num().unwrap() as i32;
 
         let margins = [
             common.margins.top.get_num().unwrap() as i32,

--- a/crates/frontend/src/wayland/draw.rs
+++ b/crates/frontend/src/wayland/draw.rs
@@ -26,7 +26,7 @@ impl DrawCore {
     }
 }
 
-/// in: content_size, visible_y, preview_size
+/// in: content_size, offset, visible_y, preview_size
 /// out: coordinate to translate, is will be <=0, size revealed
 type VisibleYFunc = fn((i32, i32), i32, f64, NumOrRelative) -> i32;
 
@@ -42,10 +42,11 @@ fn make_visible_y_func(edge: Anchor) -> VisibleYFunc {
 
     macro_rules! a {
         ($n:ident, $t:tt) => {
-            fn $n(size: (i32, i32), offset: i32, ts_y: f64, preview: NumOrRelative) -> i32 {
+            fn $n(size: (i32, i32), offset: i32, progress: f64, preview: NumOrRelative) -> i32 {
                 let preview = cal_pre!(size.$t, preview);
-                let progress = ((size.$t + offset) as f64 * ts_y).ceil() as i32;
-                preview.max(progress)
+                let total = size.$t + offset;
+                let visable = (total as f64 * progress).ceil() as i32;
+                visable.max(preview)
             }
         };
     }


### PR DESCRIPTION
I was trying to add padding to the widget using `"margins": {"left": 10}` for a left-edge widget, but the trigger area also shifted to the right, which is not what I intended.
This change adds a configuration field `offset` for widgets, unlike `margin`, `offset` will not change the trigger area, the trigger area will remain near the edges.
I considered naming this field "padding", but since this offset should only affect the edge direction, and `outlook.margin` already handles the actual padding, so I named it "offset".

```
before:
     +--------------------+
     | +----------------+ |
     | |  trigger area  | |
     | +----------------+ |
     | |                | |
     | |                | |
     | |     widget     | |
     | |                | |
     | |                | |
     | +----------------+ |
     |   margin    area   |
     +--------------------+
--------- bottom edge ---------

after:
     +--------------------+
     | +----------------+ |
     | |  trigger area  | |
     | +----------------+ |
     | |                | |
     | |     widget     | |
     | |                | |
     | +----------------+ |
     | |     offset     | |
     | +----------------+ |
     |   margin    area   |
     +--------------------+
--------- bottom edge ---------
```
This is how it looks:

https://github.com/user-attachments/assets/e70ce4e9-db84-49e8-95d8-2b79aa7a7c77

