### PR TITLE
feat: round all corners for widgets with offset

### DIFF
--- a/crates/config/src/shared.rs
+++ b/crates/config/src/shared.rs
@@ -62,6 +62,12 @@ impl NumOrRelative {
             NumOrRelative::Relative(_) => true,
         }
     }
+    pub fn is_zero(&self) -> bool {
+        match self {
+            NumOrRelative::Num(r) => *r == 0.,
+            NumOrRelative::Relative(r) => *r == 0.,
+        }
+    }
     pub fn get_num(&self) -> Result<f64, &str> {
         if let Self::Num(r) = self {
             Ok(*r)

--- a/crates/frontend/src/widgets/wrapbox/mod.rs
+++ b/crates/frontend/src/widgets/wrapbox/mod.rs
@@ -42,7 +42,11 @@ impl WidgetContext for BoxContext {
 }
 
 pub fn init_widget(builder: &mut WidgetBuilder, w_conf: BoxConfig) -> impl WidgetContext {
-    let outlook_draw_conf = init_outlook(&w_conf.outlook, builder.common_config.edge);
+    let outlook_draw_conf = init_outlook(
+        &w_conf.outlook,
+        builder.common_config.edge,
+        builder.common_config.offset,
+    );
     let grid_box = init_boxed_widgets(builder, w_conf);
 
     BoxContext {

--- a/crates/frontend/src/widgets/wrapbox/outlook/board.rs
+++ b/crates/frontend/src/widgets/wrapbox/outlook/board.rs
@@ -1,6 +1,9 @@
 use cairo::ImageSurface;
 
-use config::widgets::wrapbox::{OutlookBoardConfig, OutlookMargins};
+use config::{
+    shared::NumOrRelative,
+    widgets::wrapbox::{OutlookBoardConfig, OutlookMargins},
+};
 use cosmic_text::Color;
 use smithay_client_toolkit::shell::wlr_layer::Anchor;
 use util::{
@@ -19,13 +22,16 @@ pub struct DrawConf {
     corners: [bool; 4],
 }
 impl DrawConf {
-    pub fn new(outlook: &OutlookBoardConfig, edge: Anchor) -> Self {
-        let corners = match edge {
-            Anchor::LEFT => [false, true, true, false],
-            Anchor::RIGHT => [true, false, false, true],
-            Anchor::TOP => [false, false, true, true],
-            Anchor::BOTTOM => [true, true, false, false],
-            _ => unreachable!(),
+    pub fn new(outlook: &OutlookBoardConfig, edge: Anchor, offset: NumOrRelative) -> Self {
+        let corners = match offset.is_zero() {
+            false => [true; 4],
+            true => match edge {
+                Anchor::LEFT => [false, true, true, false],
+                Anchor::RIGHT => [true, false, false, true],
+                Anchor::TOP => [false, false, true, true],
+                Anchor::BOTTOM => [true, true, false, false],
+                _ => unreachable!(),
+            },
         };
 
         Self {

--- a/crates/frontend/src/widgets/wrapbox/outlook/mod.rs
+++ b/crates/frontend/src/widgets/wrapbox/outlook/mod.rs
@@ -1,19 +1,19 @@
 use std::fmt::Debug;
 
 use cairo::ImageSurface;
-use config::widgets::wrapbox::Outlook;
+use config::{shared::NumOrRelative, widgets::wrapbox::Outlook};
 use smithay_client_toolkit::shell::wlr_layer::Anchor;
 
 mod board;
 mod window;
 
-pub fn init_outlook(outlook: &Outlook, edge: Anchor) -> Box<dyn OutlookDraw> {
+pub fn init_outlook(outlook: &Outlook, edge: Anchor, offset: NumOrRelative) -> Box<dyn OutlookDraw> {
     match outlook {
         Outlook::Window(outlook_window_config) => {
-            Box::new(window::DrawConf::new(outlook_window_config, edge))
+            Box::new(window::DrawConf::new(outlook_window_config, edge, offset))
         }
         Outlook::Board(outlook_board_config) => {
-            Box::new(board::DrawConf::new(outlook_board_config, edge))
+            Box::new(board::DrawConf::new(outlook_board_config, edge, offset))
         }
     }
 }

--- a/crates/frontend/src/widgets/wrapbox/outlook/window.rs
+++ b/crates/frontend/src/widgets/wrapbox/outlook/window.rs
@@ -1,6 +1,6 @@
 use cairo::ImageSurface;
 
-use config::widgets::wrapbox::{OutlookMargins, OutlookWindowConfig};
+use config::{shared::NumOrRelative, widgets::wrapbox::{OutlookMargins, OutlookWindowConfig}};
 use cosmic_text::Color;
 use smithay_client_toolkit::shell::wlr_layer::Anchor;
 use util::{
@@ -21,13 +21,16 @@ pub struct DrawConf {
     corners: [bool; 4],
 }
 impl DrawConf {
-    pub fn new(outlook: &OutlookWindowConfig, edge: Anchor) -> Self {
-        let corners = match edge {
-            Anchor::LEFT => [false, true, true, false],
-            Anchor::RIGHT => [true, false, false, true],
-            Anchor::TOP => [false, false, true, true],
-            Anchor::BOTTOM => [true, true, false, false],
-            _ => unreachable!(),
+    pub fn new(outlook: &OutlookWindowConfig, edge: Anchor, offset: NumOrRelative) -> Self {
+        let corners = match offset.is_zero() {
+            false => [true; 4],
+            true => match edge {
+                Anchor::LEFT => [false, true, true, false],
+                Anchor::RIGHT => [true, false, false, true],
+                Anchor::TOP => [false, false, true, true],
+                Anchor::BOTTOM => [true, true, false, false],
+                _ => unreachable!(),
+            },
         };
 
         Self {


### PR DESCRIPTION
Before:
<img width="204" height="242" alt="image" src="https://github.com/user-attachments/assets/c4278f0e-16d8-4d15-83dc-f60f1e8f8f38" />
After:
<img width="204" height="230" alt="image" src="https://github.com/user-attachments/assets/dfe4fdb3-e7cc-42f3-87e3-7bba64b1d66c" />
